### PR TITLE
Change action to container action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,9 @@ inputs:
     required: false
     description: 'Datadog site'
   public_ids: 
-    required: false
+    required: true
     description: 'Public IDs of Synthetics test to run'
-
   
 runs:
   using: docker
-  main: Dockerfile
+  image: Dockerfile


### PR DESCRIPTION
To avoid having to add all dist files, we setup the action as a container action using the working directory's Dockerfile