### PR TITLE
[SW-1619] fix import error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ const run = async (): Promise<void> => {
       resultSummary.criticalErrors > 0 ||
       resultSummary.failed > 0 ||
       resultSummary.timedOut > 0 ||
-      resultSummary.notFound > 0
+      resultSummary.testsNotFound.size > 0
     ) {
       core.setFailed(`Datadog Synthetics tests failed : ${printSummary(resultSummary)}`)
     } else {
@@ -47,7 +47,7 @@ const run = async (): Promise<void> => {
 }
 
 export const printSummary = (summary: Summary) =>
-`criticalErrors: ${summary.criticalErrors}, passed: ${summary.passed}, failed: ${summary.failed}, skipped: ${summary.skipped}, notFound: ${summary.notFound}, timedOut: ${summary.timedOut}`
+`criticalErrors: ${summary.criticalErrors}, passed: ${summary.passed}, failed: ${summary.failed}, skipped: ${summary.skipped}, notFound: ${summary.testsNotFound.size}, timedOut: ${summary.timedOut}`
 
 if (require.main === module) {
   run()


### PR DESCRIPTION
As part of https://github.com/DataDog/datadog-ci/pull/406, the interface of internal type `Summary` from `datadog-ci` changed.
The source in this repository relied on this internal type
The package version was then bumped and a new release was created: https://github.com/DataDog/datadog-ci/pull/409
Following which, dependabot updated the used version in this repo, breaking the code that relied on the older type: https://github.com/DataDog/synthetics-ci-github-action/pull/31

To avoid this error to happen again, we should:
- clearly export the modules from `datadog-ci` that are required externally (`main` in `package.json`)
- bump the minor or major version when modifying these exported modules
- run the unit tests, and require these tests to succeed to merge into main.