### PR TITLE
[repo] disable dependabot config in repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  # Enable version updates for npm
-  - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `root` directory
-    directory: '/'
-    # Check the npm registry for updates every day (weekdays)
-    schedule:
-      interval: 'daily'


### PR DESCRIPTION
Instead of having the config in the repo we want to use the config
accessible through repository's settings.