### PR TITLE
Update README to recommend use of GitHub secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Trigger Synthetic tests from your GitHub workflows with the [Datadog CI Syntheti
 
 To get started:
 
-1. Add your Datadog API and Application Keys as environment variables to your GitHub repository. For more information, see [API and Application Keys][2].
+1. Add your Datadog API and Application Keys as secrets to your GitHub repository. For more information, see [API and Application Keys][2].
 2. In your GitHub workflow, use `DataDog/synthetics-ci-github-action`.
 
 Your workflow can be [simple](#simple-workflows) or [complex](#complex-workflows).


### PR DESCRIPTION
We use secrets in the README example workflows, we should keep the consistency throughout.