### PR TITLE
[config] Remove support for `tunnel` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,31 +90,29 @@ jobs:
 
 ## Inputs
 
-| Name                | Type    | Requirement | Description                                                                                                                                                                                              |
-| ------------------- | ------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `api_key`           | string  | _required_  | Your Datadog API key. This key is created by your [Datadog organization][2] and should be stored as a [secret][3]. **Default:** none.                                                                    |
-| `app_key`           | string  | _required_  | Your Datadog Application key. This key is created by your [Datadog organization][2] and should be stored as a [secret][3]. **Default:** none.                                                            |
-| `public_ids`        | string  | _optional_  | String of public IDs separated by commas for Synthetic tests you want to trigger. If no value is provided, the action looks for files named with `synthetics.json`. **Default:** none.                   |
-| `test_search_query` | string  | _optional_  | Trigger tests corresponding to a [search][5] query. **Default:** none.                                                                                                                                   |
-| `tunnel`            | boolean | _optional_  | Use the [testing tunnel][6] to trigger tests. **Default:** false.                                                                                                                                        |
-| `subdomain`         | string  | _optional_  | The name of the custom subdomain set to access your Datadog application. If the URL used to access Datadog is `myorg.datadoghq.com`, the subdomain value needs to be set to `myorg`. **Default:** `app`. |
-| `files`             | string  | _optional_  | Glob pattern to detect Synthetic tests config files. **Default:** `{,!(node_modules)/**/}*.synthetics.json`.                                                                                             |
-| `datadog_site`      | string  | _optional_  | The Datadog site. For users in the EU, set to `datadoghq.eu`. For example: `datadoghq.com` or `datadoghq.eu`. **Default:** `datadoghq.com`.                                                              |
-| `config_path`       | string  | _optional_  | The global JSON configuration is used when launching tests. See the [example configuration][4] for more details. **Default:** `datadog-ci.json`.                                                         |
+| Name                | Type   | Requirement | Description                                                                                                                                                                                              |
+| ------------------- | ------ | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api_key`           | string | _required_  | Your Datadog API key. This key is created by your [Datadog organization][2] and should be stored as a [secret][3]. **Default:** none.                                                                    |
+| `app_key`           | string | _required_  | Your Datadog Application key. This key is created by your [Datadog organization][2] and should be stored as a [secret][3]. **Default:** none.                                                            |
+| `public_ids`        | string | _optional_  | String of public IDs separated by commas for Synthetic tests you want to trigger. If no value is provided, the action looks for files named with `synthetics.json`. **Default:** none.                   |
+| `test_search_query` | string | _optional_  | Trigger tests corresponding to a [search][5] query. **Default:** none.                                                                                                                                   |
+| `subdomain`         | string | _optional_  | The name of the custom subdomain set to access your Datadog application. If the URL used to access Datadog is `myorg.datadoghq.com`, the subdomain value needs to be set to `myorg`. **Default:** `app`. |
+| `files`             | string | _optional_  | Glob pattern to detect Synthetic tests config files. **Default:** `{,!(node_modules)/**/}*.synthetics.json`.                                                                                             |
+| `datadog_site`      | string | _optional_  | The Datadog site. For users in the EU, set to `datadoghq.eu`. For example: `datadoghq.com` or `datadoghq.eu`. **Default:** `datadoghq.com`.                                                              |
+| `config_path`       | string | _optional_  | The global JSON configuration is used when launching tests. See the [example configuration][4] for more details. **Default:** `datadog-ci.json`.                                                         |
 
 ## Further Reading
 
 Additional helpful documentation, links, and articles:
 
-- [CI/CD Integrations Configuration][7]
+- [CI/CD Integrations Configuration][6]
 
 [1]: https://github.com/DataDog/datadog-ci
 [2]: https://docs.datadoghq.com/account_management/api-app-keys/
 [3]: https://docs.github.com/en/actions/reference/encrypted-secrets
 [4]: https://docs.datadoghq.com/synthetics/cicd_integrations/configuration/?tab=npm#setup-a-client
 [5]: https://docs.datadoghq.com/synthetics/search/#search
-[6]: https://docs.datadoghq.com/synthetics/cicd_integrations/configuration/?tab=npm#use-the-testing-tunnel
-[7]: https://docs.datadoghq.com/synthetics/cicd_integrations/configuration
+[6]: https://docs.datadoghq.com/synthetics/cicd_integrations/configuration
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -2,34 +2,31 @@ name: 'Datadog Synthetics CI'
 description: 'Run Datadog Synthetics CI tests as part of your Github Actions workflow'
 author: 'Datadog'
 inputs:
-  api_key: 
+  api_key:
     required: true
     description: 'Datadog API key.'
-  app_key: 
+  app_key:
     required: true
     description: 'Datadog Application key.'
-  datadog_site: 
+  datadog_site:
     required: false
     description: 'Datadog site.'
-  public_ids: 
+  public_ids:
     required: false
     description: 'Public IDs of Synthetics test to run.'
-  config_path: 
+  config_path:
     required: false
     description: 'Path to global configuration JSON.'
-  files: 
+  files:
     required: false
     description: 'Glob pattern to detect synthetic tests config.'
-  subdomain: 
+  subdomain:
     required: false
     description: 'Name of your datadog custom subdomain.'
-  test_search_query: 
+  test_search_query:
     required: false
     description: 'Search query to trigger tests.'
-  tunnel: 
-    required: false
-    description: 'Use tunnel to trigger tests.'
-  
+
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/resolve-config.ts
+++ b/src/resolve-config.ts
@@ -40,7 +40,6 @@ export const resolveConfig = async (): Promise<synthetics.SyntheticsCIConfig> =>
     .map((file: string) => file.trim())
   const testSearchQuery = getDefinedInput('test_search_query')
   const subdomain = getDefinedInput('subdomain')
-  const tunnel = getDefinedInput('tunnel')
 
   let config = JSON.parse(JSON.stringify(DEFAULT_CONFIG))
   // Override with file config variables
@@ -66,7 +65,6 @@ export const resolveConfig = async (): Promise<synthetics.SyntheticsCIConfig> =>
       publicIds,
       subdomain,
       testSearchQuery,
-      tunnel,
     })
   )
 


### PR DESCRIPTION
Remove support for `tunnel` option which is currently not relevant in the context of Github Actions. 
There are no convenient way of maintaining a local server running during the action execution, if to be supported, the action itself should offer a wrapper around a custom server launch command.