### PR TITLE
Fix CSV table in LICENSE-3rdparty.csv

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,5 +1,5 @@
 @actions/core,import,MIT,Copyright 2019 GitHub
-@datadog/datadog-ci,import,Apache-2.0,Copyright 2019-Present Datadog, Inc.
+@datadog/datadog-ci,import,Apache-2.0,"Copyright 2019-Present Datadog, Inc."
 @types/deep-extend,dev,MIT,Copyright Microsoft Corporation
 @types/jest,dev,MIT,Copyright Microsoft Corporation
 @types/node,dev,MIT,Copyright Microsoft Corporation


### PR DESCRIPTION
The comma from `Datadog, Inc` is viewed as a new column in the `LICENSE-3rdparty.csv` file.

And because of this, GitHub fails to render the CSV file as a table. It could also break other tooling.

<img width="1235" alt="image" src="https://user-images.githubusercontent.com/9317502/183940180-70580244-6070-45d8-a88b-1ee445e51ffb.png">
