### PR TITLE
Only use yarn scripts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ jobs:
 ```bash
 
 # Run the tests
-yarn jest
+yarn test
 
 # Build project
 yarn build


### PR DESCRIPTION
The script effectively does the same:

```json
"scripts": {
    "build": "tsc",
    "lint": "eslint src/**/*.ts",
    "test": "jest"  <--
  },
```

But it's more consistent to only say to run yarn scripts instead of `jest` directly for this command only.