### PR TITLE
Fix `variables` input not being used

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -69,6 +69,29 @@ describe('Run Github Action', () => {
         publicIds,
       })
     })
+
+    test('Github Action parses out variables string', async () => {
+      process.env = {
+        ...process.env,
+        INPUT_VARIABLES: 'START_URL=https://example.org,MY_VARIABLE=My title',
+      }
+
+      jest.spyOn(synthetics, 'executeTests').mockImplementation(() => ({} as any))
+
+      await run()
+      expect(synthetics.executeTests).toHaveBeenCalledWith(expect.anything(), {
+        ...config,
+        ...inputs,
+        global: {
+          variables: {
+            START_URL: 'https://example.org',
+            MY_VARIABLE: 'My title',
+          },
+        },
+      })
+
+      delete process.env.INPUT_VARIABLES
+    })
   })
 
   describe('Handle invalid input parameters', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ const run = async (): Promise<void> => {
 
   synthetics.utils.setCiTriggerApp('github_action')
   const reporter = synthetics.utils.getReporter([new synthetics.DefaultReporter({context})])
-  const config = await resolveConfig()
+  const config = await resolveConfig(reporter)
 
   try {
     const startTime = Date.now()

--- a/src/resolve-config.ts
+++ b/src/resolve-config.ts
@@ -22,7 +22,7 @@ const DEFAULT_CONFIG: synthetics.CommandConfig = {
   variableStrings: [],
 }
 
-export const resolveConfig = async (): Promise<synthetics.CommandConfig> => {
+export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<synthetics.CommandConfig> => {
   let apiKey
   let appKey
   try {
@@ -70,7 +70,12 @@ export const resolveConfig = async (): Promise<synthetics.CommandConfig> => {
       publicIds,
       subdomain,
       testSearchQuery,
-      variableStrings,
+      global: deepExtend(
+        config.global,
+        removeUndefinedValues({
+          variables: synthetics.utils.parseVariablesFromCli(variableStrings, reporter.log.bind(reporter)),
+        })
+      ),
     })
   )
 


### PR DESCRIPTION
We are setting `config.variableStrings` using the value of the `variables` input.

However, since the Action uses `synthetics.executeTests` instead of `synthetics.execute` to run the tests, `config.variableStrings` is never parsed into `config.global.variables` (cf. [this part in datadog-ci](https://github.com/DataDog/datadog-ci/blob/0ee79438390f2ddca3d41251dc4984b3c7381e0c/src/commands/synthetics/command.ts#L194), which is only used when calling `synthetics.execute`).

This is why the variables set in the workflows are not actually used.

This PR fixes this behavior, by parsing the variables directly in the Action, using the `synthetics.utils.parseVariablesFromCli` function.