### PR TITLE
Upgrade to use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ inputs:
     description: 'Comma-separated list of variable_name=variable_value pairs.'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
This PR updates the using runtime to node16, rather than node12.
ref: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
