### PR TITLE
Release `v0.9.1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ To release a new version of `synthetics-ci-github-action`:
 
    Create a pull request with the changes introduced in the description. This pull request requires at least one approval.
 
-5. **Merge** (do not use "Squash and Merge") the pull request.
+5. Merge the pull request.
 6. Create a GitHub Release from the [Tags page][8] with a description of your changes.
 
 ⚠️ Ensure the release version follows the expected format `vX.Y.Z`.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run Datadog Synthetics tests
-        uses: DataDog/synthetics-ci-github-action@v0.9.0
+        uses: DataDog/synthetics-ci-github-action@v0.9.1
         with:
           api_key: ${{secrets.DD_API_KEY}}
           app_key: ${{secrets.DD_APP_KEY}}
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run Datadog Synthetics tests
-        uses: DataDog/synthetics-ci-github-action@v0.9.0
+        uses: DataDog/synthetics-ci-github-action@v0.9.1
         with:
           api_key: ${{secrets.DD_API_KEY}}
           app_key: ${{secrets.DD_APP_KEY}}
@@ -63,7 +63,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run Datadog Synthetics tests
-        uses: DataDog/synthetics-ci-github-action@v0.9.0
+        uses: DataDog/synthetics-ci-github-action@v0.9.1
         with:
           api_key: ${{secrets.DD_API_KEY}}
           app_key: ${{secrets.DD_APP_KEY}}
@@ -81,7 +81,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run Datadog Synthetics tests
-        uses: DataDog/synthetics-ci-github-action@v0.9.0
+        uses: DataDog/synthetics-ci-github-action@v0.9.1
         with:
           api_key: ${{secrets.DD_API_KEY}}
           app_key: ${{secrets.DD_APP_KEY}}
@@ -100,7 +100,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run Datadog Synthetics tests
-        uses: DataDog/synthetics-ci-github-action@v0.9.0
+        uses: DataDog/synthetics-ci-github-action@v0.9.1
         with:
           api_key: ${{secrets.DD_API_KEY}}
           app_key: ${{secrets.DD_APP_KEY}}
@@ -149,7 +149,7 @@ To release a new version of `synthetics-ci-github-action`:
 
    Create a pull request with the changes introduced in the description. This pull request requires at least one approval.
 
-5. Merge the pull request.
+5. **Merge** (do not use "Squash and Merge") the pull request.
 6. Create a GitHub Release from the [Tags page][8] with a description of your changes.
 
 ⚠️ Ensure the release version follows the expected format `vX.Y.Z`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-synthetics-github-action",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "Datadog",
   "description": "Run Datadog Synthetics CI tests as part of your Github Actions workflow",
   "main": "lib/main.js",


### PR DESCRIPTION
The `v0.9.0` release didn't work as expected because the git tag `v0.9.0` was not set on the commit introducing the changes.

(I suspect the `git commit --amend` command to un-assign the tag from the amended commit)