### PR TITLE
Add `junit_report` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ jobs:
 | `datadog_site`      | string  | _optional_  | The Datadog site. For users in the EU, set to `datadoghq.eu`. For example: `datadoghq.com` or `datadoghq.eu`. **Default:** `datadoghq.com`.                                                              |
 | `config_path`       | string  | _optional_  | The global JSON configuration is used when launching tests. See the [example configuration][4] for more details. **Default:** `datadog-ci.json`.                                                         |
 | `variables`         | string  | _optional_  | Comma-separated list of global variables to use for Synthetic tests. For example: `START_URL=https://example.org,MY_VARIABLE=My title`. **Default:** `[]`.                                               |
+| `junit_report`      | string  | _optional_  | The filename for a JUnit report if you want to generate one. **Default:** none.                                                                                                                          |
 | `tunnel`            | boolean | _optional_  | Use the [secure tunnel][9] to execute your test batch. **Default:** `false`.                                                                                                                             |
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
   variables:
     required: false
     description: 'Comma-separated list of variable_name=variable_value pairs.'
+  junit_report:
+    required: false
+    description: 'The filename for a JUnit report if you want to generate one.'
 
 runs:
   using: 'node16'

--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -31,3 +31,14 @@ export const mockReporter: synthetics.MainReporter = {
   testWait: jest.fn(),
   testsWait: jest.fn(),
 }
+
+export const EMPTY_SUMMARY: synthetics.Summary = {
+  criticalErrors: 0,
+  passed: 0,
+  failed: 0,
+  failedNonBlocking: 0,
+  skipped: 0,
+  testsNotFound: new Set(),
+  timedOut: 0,
+  batchId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,19 +1,13 @@
 import * as core from '@actions/core'
-import {BaseContext} from 'clipanion'
+import {getReporter, resolveConfig} from './resolve-config'
 import {renderResults} from './process-results'
 import {reportCiError} from './report-ci-error'
-import {resolveConfig} from './resolve-config'
 import {synthetics} from '@datadog/datadog-ci'
 
 const run = async (): Promise<void> => {
-  const context: BaseContext = {
-    stdin: process.stdin,
-    stdout: process.stdout,
-    stderr: process.stderr,
-  }
-
   synthetics.utils.setCiTriggerApp('github_action')
-  const reporter = synthetics.utils.getReporter([new synthetics.DefaultReporter({context})])
+
+  const reporter = getReporter()
   const config = await resolveConfig(reporter)
 
   try {

--- a/src/resolve-config.ts
+++ b/src/resolve-config.ts
@@ -1,8 +1,8 @@
 import * as core from '@actions/core'
 import {synthetics, utils} from '@datadog/datadog-ci'
+import {BaseContext} from 'clipanion'
+import {Reporter} from '@datadog/datadog-ci/dist/commands/synthetics'
 import deepExtend from 'deep-extend'
-
-import {removeUndefinedValues} from './utils'
 
 const DEFAULT_CONFIG: synthetics.CommandConfig = {
   apiKey: '',
@@ -63,7 +63,7 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
   // Override with GithubAction inputs
   config = deepExtend(
     config,
-    removeUndefinedValues({
+    utils.removeUndefinedValues({
       apiKey,
       appKey,
       configPath,
@@ -75,7 +75,7 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
       tunnel,
       global: deepExtend(
         config.global,
-        removeUndefinedValues({
+        utils.removeUndefinedValues({
           variables: synthetics.utils.parseVariablesFromCli(variableStrings, reporter.log.bind(reporter)),
         })
       ),
@@ -101,4 +101,21 @@ export const getDefinedBoolean = (name: string): boolean | undefined => {
     core.setFailed(String(error))
     throw error
   }
+}
+
+export const getReporter = (): synthetics.MainReporter => {
+  const context: BaseContext = {
+    stdin: process.stdin,
+    stdout: process.stdout,
+    stderr: process.stderr,
+  }
+
+  const reporters: Reporter[] = [new synthetics.DefaultReporter({context})]
+
+  const jUnitReportFilename = getDefinedInput('junit_report')
+  if (jUnitReportFilename) {
+    reporters.push(new synthetics.JUnitReporter({context, jUnitReport: jUnitReportFilename}))
+  }
+
+  return synthetics.utils.getReporter(reporters)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,0 @@
-export const removeUndefinedValues = <T extends {[key: string]: unknown}>(object: T): T => {
-  const newObject = {...object}
-  for (const [key, value] of Object.entries(newObject)) {
-    if (value === undefined) {
-      delete newObject[key]
-    }
-  }
-  return newObject
-}


### PR DESCRIPTION
Depends on: https://github.com/DataDog/datadog-ci/pull/774 (and the [corresponding bump](https://github.com/DataDog/synthetics-ci-github-action/pull/116))

This PR adds a `junit_report` input, so that you can build a JUnit XML report of the tests that were run.