### PR TITLE
[ci] Add manual workflows for bump and release PRs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 dist/
 lib/
+ci/
 node_modules/
 jest.config.js

--- a/.github/workflows/bump-datadog-ci.yml
+++ b/.github/workflows/bump-datadog-ci.yml
@@ -1,0 +1,77 @@
+# This workflow automatically creates a release PR for the CI integration.
+
+name: Bump Datadog CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      datadog_ci_version:
+        description: "Version of datadog-ci to install (`latest` or `A.B.C`)"
+        type: string
+        default: "latest"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump-datadog-ci:
+    runs-on: ubuntu-latest
+    steps:
+      # Do the changes
+      - uses: actions/checkout@v3
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "lts/*"
+      - name: Create release branch
+        run: git checkout -b local-branch
+      - name: Set git user
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email noreply@github.com
+      - name: Install dependencies
+        run: yarn install
+      - name: Bump datadog-ci
+        id: bump-datadog-ci
+        run: |
+          VERSION=${{ github.event.inputs.datadog_ci_version }}
+          if [ "$VERSION" = "latest" ]; then
+            VERSION=$(npm view @datadog/datadog-ci --json | jq -r '.version')
+          fi
+
+          yarn add @datadog/datadog-ci@^$VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+      - name: Create bump commit
+        run: git commit -a --message '[dep] Bump datadog-ci to `${{ steps.bump-datadog-ci.outputs.VERSION }}`'
+      - name: Push the branch
+        run: git push -u origin local-branch:bump-datadog-ci/${{ steps.bump-datadog-ci.outputs.VERSION }}
+
+      # Create the pull request
+      - name: Create pull request
+        id: create-pull-request
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: 'main',
+              head: 'bump-datadog-ci/${{ steps.bump-datadog-ci.outputs.VERSION }}',
+              title: '[dep] Bump datadog-ci to `${{ steps.bump-datadog-ci.outputs.VERSION }}`',
+              body: 'This PR bumps [datadog-ci](https://github.com/DataDog/datadog-ci) to version [`${{ steps.bump-datadog-ci.outputs.VERSION }}`](https://github.com/DataDog/datadog-ci/releases/tag/v${{ steps.bump-datadog-ci.outputs.VERSION }})'
+            })
+
+            return pullRequest.number
+      - name: Create comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { bumpDatadogCiComment } = require('./ci/pull-request-comments')
+
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{steps.create-pull-request.outputs.result}},
+              body: bumpDatadogCiComment,
+            })

--- a/.github/workflows/bump-datadog-ci.yml
+++ b/.github/workflows/bump-datadog-ci.yml
@@ -62,7 +62,7 @@ jobs:
               body: 'This PR bumps [datadog-ci](https://github.com/DataDog/datadog-ci) to version [`${{ steps.bump-datadog-ci.outputs.VERSION }}`](https://github.com/DataDog/datadog-ci/releases/tag/v${{ steps.bump-datadog-ci.outputs.VERSION }})'
             })
 
-            return pullRequest.number
+            core.setOutput('PULL_REQUEST_NUMBER', pullRequest.number)
       - name: Create comment
         uses: actions/github-script@v6
         with:
@@ -72,6 +72,6 @@ jobs:
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{steps.create-pull-request.outputs.result}},
+              issue_number: ${{steps.create-pull-request.outputs.PULL_REQUEST_NUMBER}},
               body: bumpDatadogCiComment,
             })

--- a/.github/workflows/bump-datadog-ci.yml
+++ b/.github/workflows/bump-datadog-ci.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       datadog_ci_version:
-        description: "Version of datadog-ci to install (`latest` or `A.B.C`)"
+        description: 'Version of datadog-ci to install (`latest` or `A.B.C`)'
         type: string
-        default: "latest"
+        default: 'latest'
 
 permissions:
   contents: write
@@ -23,7 +23,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v3
         with:
-          node-version: "lts/*"
+          node-version: 'lts/*'
       - name: Create release branch
         run: git checkout -b local-branch
       - name: Set git user

--- a/.github/workflows/bump-datadog-ci.yml
+++ b/.github/workflows/bump-datadog-ci.yml
@@ -72,6 +72,6 @@ jobs:
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{steps.create-pull-request.outputs.PULL_REQUEST_NUMBER}},
+              issue_number: ${{ steps.create-pull-request.outputs.PULL_REQUEST_NUMBER }},
               body: bumpDatadogCiComment,
             })

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
     inputs:
       semver:
-        description: "Semver argument for the version bump to do on the CI integration"
-        default: "minor"
+        description: 'Semver argument for the version bump to do on the CI integration'
+        default: 'minor'
         type: choice
         options:
-          - "minor"
+          - 'minor'
 
 permissions:
   contents: write
@@ -25,7 +25,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: '16'
       - name: Create release branch
         run: git checkout -b local-branch
       - name: Set git user

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -1,0 +1,94 @@
+# This workflow automatically creates a release PR for the CI integration.
+
+name: Create Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      semver:
+        description: "Semver argument for the version bump to do on the CI integration"
+        required: true
+        default: "minor"
+        type: choice
+        options:
+          # - "patch"
+          - "minor"
+          # - "major"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      # Do the changes
+      - uses: actions/checkout@v3
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+      - name: Create release branch
+        run: git checkout -b local-branch
+      - name: Set git user
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email noreply@github.com
+      - name: Install dependencies
+        run: yarn install
+      - name: Bump CI integration version
+        run: yarn version --${{ github.event.inputs.semver }}
+      - name: Update build files
+        run: yarn build && yarn package
+      - name: Amend version commit
+        id: amend-version-commit
+        run: |
+          VERSION_TAG=$(git tag --points-at HEAD)
+          git add --all
+          git commit --amend --no-edit
+          git tag --force $VERSION_TAG
+          echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_OUTPUT
+      - name: Push the branch (with tags)
+        run: git push --follow-tags -u origin local-branch:release/${{ steps.amend-version-commit.outputs.VERSION_TAG }}
+
+      # Create the pull request
+      - name: Generate release notes
+        id: generate-release-notes
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: releaseNotes } = await github.rest.repos.generateReleaseNotes({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: '${{ steps.amend-version-commit.outputs.VERSION_TAG }}',
+            })
+
+            return releaseNotes.body
+      - name: Create pull request
+        id: create-pull-request
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: 'main',
+              head: 'release/${{ steps.amend-version-commit.outputs.VERSION_TAG }}',
+              title: '[release:${{ github.event.inputs.semver }}] `${{ steps.amend-version-commit.outputs.VERSION_TAG }}`',
+              body: ${{ steps.generate-release-notes.outputs.result }}
+            })
+
+            return pullRequest.number
+      - name: Create comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { releaseVersionComment } = require('./ci/pull-request-comments')
+
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{steps.create-pull-request.outputs.result}},
+              body: releaseVersionComment,
+            })

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -7,13 +7,10 @@ on:
     inputs:
       semver:
         description: "Semver argument for the version bump to do on the CI integration"
-        required: true
         default: "minor"
         type: choice
         options:
-          # - "patch"
           - "minor"
-          # - "major"
 
 permissions:
   contents: write

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -61,7 +61,7 @@ jobs:
               tag_name: '${{ steps.amend-version-commit.outputs.VERSION_TAG }}',
             })
 
-            return releaseNotes.body
+            core.setOutput('RELEASE_NOTES', releaseNotes.body)
       - name: Create pull request
         id: create-pull-request
         uses: actions/github-script@v6
@@ -73,10 +73,10 @@ jobs:
               base: 'main',
               head: 'release/${{ steps.amend-version-commit.outputs.VERSION_TAG }}',
               title: '[release:${{ github.event.inputs.semver }}] `${{ steps.amend-version-commit.outputs.VERSION_TAG }}`',
-              body: ${{ steps.generate-release-notes.outputs.result }}
+              body: ${{ toJSON(steps.generate-release-notes.outputs.RELEASE_NOTES) }}
             })
 
-            return pullRequest.number
+            core.setOutput('PULL_REQUEST_NUMBER', pullRequest.number)
       - name: Create comment
         uses: actions/github-script@v6
         with:
@@ -86,6 +86,6 @@ jobs:
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{steps.create-pull-request.outputs.result}},
+              issue_number: ${{ steps.create-pull-request.outputs.PULL_REQUEST_NUMBER }},
               body: releaseVersionComment,
             })

--- a/ci/pull-request-comments.js
+++ b/ci/pull-request-comments.js
@@ -1,0 +1,6 @@
+module.exports = {
+  bumpDatadogCiComment: `This PR was automatically created because a new version of datadog-ci was published.
+Once merged, please use [this manual workflow](../actions/workflows/release-version.yml) to release the CI integration.`,
+  releaseVersionComment: `Once merged, this PR will automatically create a GitHub release for you.
+The description of the release will exactly match this PR's description. Feel free to edit it.`,
+}


### PR DESCRIPTION
- #128 ←
- #129 
---

In order to automate bumping `datadog-ci` and releasing a new version of the CI integration, we are creating workflows which will simplify our current process.

This PR adds 2 manual workflows:

- One workflow to automatically create a PR to bump datadog-ci. This will later be triggered from the **datadog-ci repository**'s CI when a release is created, so that we don't forget to bump datadog-ci in the integrations.
- One workflow to automatically create a release PR with release notes as a description.

The 2 workflows are separated to give us more flexibility.