### PR TITLE
Remove superfluous dependency

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -5,7 +5,6 @@
 @types/node,dev,MIT,Copyright Microsoft Corporation
 @typescript-eslint/parser,dev,BSD 2-Clause License, Copyright JS Foundation and other contributors
 @vercel/ncc,dev,MIT,"Copyright 2018 ZEIT, Inc."
-clipanion,import,MIT,Copyright (c) 2019 Mael Nison
 deep-extend,import,MIT,"Copyright (c) 2013-2018, Viacheslav Lotsmanov"
 eslint,dev,MIT,Copyright OpenJS Foundation and other contributors
 eslint-plugin-github,dev,MIT,"Copyright (c) 2016 GitHub, Inc."

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "@actions/core": "^1.9.1",
     "@datadog/datadog-ci": "^2.9.1",
-    "clipanion": "^3.0.1",
     "deep-extend": "0.6.0"
   },
   "devDependencies": {

--- a/src/resolve-config.ts
+++ b/src/resolve-config.ts
@@ -1,7 +1,5 @@
 import * as core from '@actions/core'
 import {synthetics, utils} from '@datadog/datadog-ci'
-import {BaseContext} from 'clipanion'
-import {Reporter} from '@datadog/datadog-ci/dist/commands/synthetics'
 import deepExtend from 'deep-extend'
 
 export const DEFAULT_CONFIG: synthetics.CommandConfig = {
@@ -107,17 +105,11 @@ export const getDefinedBoolean = (name: string): boolean | undefined => {
 }
 
 export const getReporter = (): synthetics.MainReporter => {
-  const context: BaseContext = {
-    stdin: process.stdin,
-    stdout: process.stdout,
-    stderr: process.stderr,
-  }
-
-  const reporters: Reporter[] = [new synthetics.DefaultReporter({context})]
+  const reporters: synthetics.Reporter[] = [new synthetics.DefaultReporter({context: process})]
 
   const jUnitReportFilename = getDefinedInput('junit_report')
   if (jUnitReportFilename) {
-    reporters.push(new synthetics.JUnitReporter({context, jUnitReport: jUnitReportFilename}))
+    reporters.push(new synthetics.JUnitReporter({context: process, jUnitReport: jUnitReportFilename}))
   }
 
   return synthetics.utils.getReporter(reporters)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2884,17 +2884,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clipanion@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "clipanion@npm:3.1.0"
-  dependencies:
-    typanion: ^3.3.1
-  peerDependencies:
-    typanion: "*"
-  checksum: bf350082e8953c697cfe35262845700012bdeb1cc490f81cd17de2fe985c8861750164509795ad95d3ee6a2b3742a1d5c6394cdf0f3ff4c4d24173a9fec3418e
-  languageName: node
-  linkType: hard
-
 "cliui@npm:^7.0.2":
   version: 7.0.4
   resolution: "cliui@npm:7.0.4"
@@ -3100,7 +3089,6 @@ __metadata:
     "@types/node": ^16.18.0
     "@typescript-eslint/parser": ^5.3.0
     "@vercel/ncc": ^0.31.1
-    clipanion: ^3.0.1
     deep-extend: 0.6.0
     eslint: ^8.39.0
     eslint-plugin-github: ^4.3.2
@@ -7393,13 +7381,6 @@ __metadata:
   version: 0.14.5
   resolution: "tweetnacl@npm:0.14.5"
   checksum: 6061daba1724f59473d99a7bb82e13f211cdf6e31315510ae9656fefd4779851cb927adad90f3b488c8ed77c106adc0421ea8055f6f976ff21b27c5c4e918487
-  languageName: node
-  linkType: hard
-
-"typanion@npm:^3.3.1":
-  version: 3.7.1
-  resolution: "typanion@npm:3.7.1"
-  checksum: 79f396a960167956999b585eb9f0baa61c79455c680778dd950261e73bf6465f5a38779cc176142099c7fbf440d578b44664632bb1e3e41769199278751d7d92
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- #122 
- #134 ←
---

The `clipanion` dependency was used to import the `BaseContext` interface only.

But we can just do pass `process` directly: `{ context: process}` (we do it [in datadog-ci](https://github.com/DataDog/datadog-ci/blob/e8f18c0030bf54ca6f81e00d58d60cb6718b6194/src/commands/synthetics/run-test.ts#L279)).