### PR TITLE
[ci] Use the "CI Integrations Release Automation" github app

### DIFF
--- a/.github/workflows/bump-datadog-ci.yml
+++ b/.github/workflows/bump-datadog-ci.yml
@@ -1,6 +1,10 @@
-# This workflow automatically creates a release PR for the CI integration.
+# This workflow automatically creates a PR bumping datadog-ci in the CI integration.
 
 name: Bump Datadog CI
+
+env:
+  GIT_AUTHOR_EMAIL: 'packages@datadoghq.com'
+  GIT_AUTHOR_NAME: 'ci.datadog-ci'
 
 on:
   workflow_dispatch:
@@ -10,26 +14,32 @@ on:
         type: string
         default: 'latest'
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   bump-datadog-ci:
     runs-on: ubuntu-latest
     steps:
       # Do the changes
+      - name: Get GitHub App token
+        id: get_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
+          private_key: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ steps.get_token.outputs.token }}
       - name: Install node
         uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
+          cache: 'yarn'
       - name: Create release branch
         run: git checkout -b local-branch
       - name: Set git user
         run: |
-          git config user.name "GitHub Actions"
-          git config user.email noreply@github.com
+          git config user.name "${GIT_AUTHOR_NAME}"
+          git config user.email "${GIT_AUTHOR_EMAIL}"
       - name: Install dependencies
         run: yarn install
       - name: Bump datadog-ci
@@ -52,6 +62,7 @@ jobs:
         id: create-pull-request
         uses: actions/github-script@v6
         with:
+          github-token: ${{ steps.get_token.outputs.token }}
           script: |
             const { data: pullRequest } = await github.rest.pulls.create({
               owner: context.repo.owner,
@@ -66,6 +77,7 @@ jobs:
       - name: Create comment
         uses: actions/github-script@v6
         with:
+          github-token: ${{ steps.get_token.outputs.token }}
           script: |
             const { bumpDatadogCiComment } = require('./ci/pull-request-comments')
 

--- a/.github/workflows/bump-datadog-ci.yml
+++ b/.github/workflows/bump-datadog-ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Do the changes
       - name: Get GitHub App token
-        id: get_token
+        id: get-token
         uses: tibdex/github-app-token@v1
         with:
           app_id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ steps.get_token.outputs.token }}
+          token: ${{ steps.get-token.outputs.token }}
       - name: Install node
         uses: actions/setup-node@v3
         with:
@@ -62,7 +62,7 @@ jobs:
         id: create-pull-request
         uses: actions/github-script@v6
         with:
-          github-token: ${{ steps.get_token.outputs.token }}
+          github-token: ${{ steps.get-token.outputs.token }}
           script: |
             const { data: pullRequest } = await github.rest.pulls.create({
               owner: context.repo.owner,
@@ -77,7 +77,7 @@ jobs:
       - name: Create comment
         uses: actions/github-script@v6
         with:
-          github-token: ${{ steps.get_token.outputs.token }}
+          github-token: ${{ steps.get-token.outputs.token }}
           script: |
             const { bumpDatadogCiComment } = require('./ci/pull-request-comments')
 

--- a/.github/workflows/release-version-on-merge.yml
+++ b/.github/workflows/release-version-on-merge.yml
@@ -1,20 +1,26 @@
+# This workflow automatically creates a GitHub release when a release PR is merged.
+
 name: On Release PR merged
 on:
   pull_request:
     types:
       - closed
 
-permissions:
-  contents: write
-
 jobs:
   release-version-on-merge:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, '[release:')
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub App token
+        id: get_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
+          private_key: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
       - name: Create GitHub release
         uses: actions/github-script@v6
         with:
+          github-token: ${{ steps.get_token.outputs.token }}
           script: |
             const tagName = '${{ github.event.pull_request.head.ref }}'.replace('release/', '')
 

--- a/.github/workflows/release-version-on-merge.yml
+++ b/.github/workflows/release-version-on-merge.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get GitHub App token
-        id: get_token
+        id: get-token
         uses: tibdex/github-app-token@v1
         with:
           app_id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
@@ -20,7 +20,7 @@ jobs:
       - name: Create GitHub release
         uses: actions/github-script@v6
         with:
-          github-token: ${{ steps.get_token.outputs.token }}
+          github-token: ${{ steps.get-token.outputs.token }}
           script: |
             const tagName = '${{ github.event.pull_request.head.ref }}'.replace('release/', '')
 

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -2,6 +2,10 @@
 
 name: Create Release PR
 
+env:
+  GIT_AUTHOR_EMAIL: 'packages@datadoghq.com'
+  GIT_AUTHOR_NAME: 'ci.datadog-ci'
+
 on:
   workflow_dispatch:
     inputs:
@@ -12,20 +16,26 @@ on:
         options:
           - 'minor'
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest
     steps:
       # Do the changes
+      - name: Get GitHub App token
+        id: get_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
+          private_key: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ steps.get_token.outputs.token }}
       - name: Install node
         uses: actions/setup-node@v3
         with:
           node-version: '16'
+          cache: 'yarn'
       - name: Create release branch
         run: git checkout -b local-branch
       - name: Set git user
@@ -54,6 +64,7 @@ jobs:
         id: generate-release-notes
         uses: actions/github-script@v6
         with:
+          github-token: ${{ steps.get_token.outputs.token }}
           script: |
             const { data: releaseNotes } = await github.rest.repos.generateReleaseNotes({
               owner: context.repo.owner,
@@ -66,6 +77,7 @@ jobs:
         id: create-pull-request
         uses: actions/github-script@v6
         with:
+          github-token: ${{ steps.get_token.outputs.token }}
           script: |
             const { data: pullRequest } = await github.rest.pulls.create({
               owner: context.repo.owner,
@@ -80,6 +92,7 @@ jobs:
       - name: Create comment
         uses: actions/github-script@v6
         with:
+          github-token: ${{ steps.get_token.outputs.token }}
           script: |
             const { releaseVersionComment } = require('./ci/pull-request-comments')
 

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Do the changes
       - name: Get GitHub App token
-        id: get_token
+        id: get-token
         uses: tibdex/github-app-token@v1
         with:
           app_id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ steps.get_token.outputs.token }}
+          token: ${{ steps.get-token.outputs.token }}
       - name: Install node
         uses: actions/setup-node@v3
         with:
@@ -64,7 +64,7 @@ jobs:
         id: generate-release-notes
         uses: actions/github-script@v6
         with:
-          github-token: ${{ steps.get_token.outputs.token }}
+          github-token: ${{ steps.get-token.outputs.token }}
           script: |
             const { data: releaseNotes } = await github.rest.repos.generateReleaseNotes({
               owner: context.repo.owner,
@@ -77,7 +77,7 @@ jobs:
         id: create-pull-request
         uses: actions/github-script@v6
         with:
-          github-token: ${{ steps.get_token.outputs.token }}
+          github-token: ${{ steps.get-token.outputs.token }}
           script: |
             const { data: pullRequest } = await github.rest.pulls.create({
               owner: context.repo.owner,
@@ -92,7 +92,7 @@ jobs:
       - name: Create comment
         uses: actions/github-script@v6
         with:
-          github-token: ${{ steps.get_token.outputs.token }}
+          github-token: ${{ steps.get-token.outputs.token }}
           script: |
             const { releaseVersionComment } = require('./ci/pull-request-comments')
 


### PR DESCRIPTION
### Context

[SYNTH-8788](https://datadoghq.atlassian.net/browse/SYNTH-8788)
[SYNTH-8789](https://datadoghq.atlassian.net/browse/SYNTH-8789)

In #128 and #129 were added 3 workflows for release automation.

However, they were using the `GITHUB_TOKEN` that is available in workflows by default.
But we then noticed this:

> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's `GITHUB_TOKEN`, a new workflow will not run even when the repository contains a workflow configured to run when `push` events occur. ([Source](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow))

So our usual workflows (e.g. for unit tests) were not running in those automated PRs, and reviewers were not automatically added (based on `CODEOWNERS`).

### Solution

This PR changes those 3 workflows to start using the "CI Integrations Release Automation" github app we created.
It has enough rights to solve the issues above.

### Notes

I used [DataDog/datadog-api-client-typescript](https://github.com/DataDog/datadog-api-client-typescript/blob/master/.github/workflows/prepare_release.yml) as an example.

The idea of `git clone`ing only the latest commit (depth of 0) and using cache for yarn come from there.

[SYNTH-8788]: https://datadoghq.atlassian.net/browse/SYNTH-8788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYNTH-8789]: https://datadoghq.atlassian.net/browse/SYNTH-8789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ