### PR TITLE
[ci] Let GitHub create the tag for the release

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -55,10 +55,9 @@ jobs:
           VERSION_TAG="v$(jq -r '.version' package.json)" # e.g. v1.1.0
           git add --all
           git commit -m $VERSION_TAG
-          git tag $VERSION_TAG
           echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_OUTPUT
-      - name: Push the branch (with tags)
-        run: git push --follow-tags -u origin local-branch:release/${{ steps.amend-version-commit.outputs.VERSION_TAG }}
+      - name: Push the branch
+        run: git push -u origin local-branch:release/${{ steps.amend-version-commit.outputs.VERSION_TAG }}
 
       # Create the pull request
       - name: Generate release notes


### PR DESCRIPTION
When tagging a commit of a PR, the tag might end up pointing to a commit that's not in the `main` branch history if we squashed a release PR.

Also, creating a github release without a tag is impossible because github releases _are tied_ to a tag. So when creating a release ([we do it here](https://github.com/DataDog/synthetics-ci-github-action/blob/ed2f8b699ee93f66b4d8d2630ba44bf0906d41d2/.github/workflows/release-version-on-merge.yml#L27-L33)), a tag **is automatically created if it doesn't exist**.

And on other integrations (like CircleCI, since https://github.com/DataDog/synthetics-test-automation-circleci-orb/pull/28), we **automatically release the production integration** when **tags are created**. So to align the process with all integrations, we need the tags to be created **when the release PR is merged**.