### PR TITLE
Add `polling_timeout` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ jobs:
 | `variables`         | string  | _optional_  | Comma-separated list of global variables to use for Synthetic tests. For example: `START_URL=https://example.org,MY_VARIABLE=My title`. **Default:** `[]`.                                               |
 | `junit_report`      | string  | _optional_  | The filename for a JUnit report if you want to generate one. **Default:** none.                                                                                                                          |
 | `tunnel`            | boolean | _optional_  | Use the [secure tunnel][9] to execute your test batch. **Default:** `false`.                                                                                                                             |
+| `polling_timeout`   | number  | _optional_  | The duration (in milliseconds) after which the action stops polling for test results. At the CI level, test results completed after this duration are considered failed. **Default:** 30 minutes.        |
+
 ## Development
 
 ```bash

--- a/__tests__/resolve-config.test.ts
+++ b/__tests__/resolve-config.test.ts
@@ -33,7 +33,7 @@ describe('Resolves Config', () => {
     }
   })
 
-  test('Default configuration parameters get overriden by global configuration file', async () => {
+  test('Default configuration parameters get overridden by global configuration file', async () => {
     const fakeReadFile = ((
       path: string,
       encoding: string,
@@ -103,6 +103,38 @@ describe('Resolves Config', () => {
         INPUT_TUNNEL: 'True',
       }
       expect((await resolveConfig.resolveConfig(mockReporter)).tunnel).toBe(true)
+    })
+  })
+
+  describe('parses integer', () => {
+    test('falls back to default if input is not set', async () => {
+      expect(resolveConfig.getDefinedInteger('polling_timeout')).toBeUndefined()
+      expect((await resolveConfig.resolveConfig(mockReporter)).pollingTimeout).toStrictEqual(30 * 60 * 1000)
+    })
+
+    test('falls back to default if input is an empty value', async () => {
+      process.env = {
+        ...process.env,
+        INPUT_POLLING_TIMEOUT: '',
+      }
+      expect(resolveConfig.getDefinedInteger('polling_timeout')).toBeUndefined()
+      expect((await resolveConfig.resolveConfig(mockReporter)).pollingTimeout).toStrictEqual(30 * 60 * 1000)
+    })
+
+    test('throws if input is a float', async () => {
+      process.env = {
+        ...process.env,
+        INPUT_POLLING_TIMEOUT: '1.2',
+      }
+      await expect(resolveConfig.resolveConfig(mockReporter)).rejects.toThrow('1.2 is not an integer')
+    })
+
+    test('returns the value if input is an integer', async () => {
+      process.env = {
+        ...process.env,
+        INPUT_POLLING_TIMEOUT: '1',
+      }
+      expect((await resolveConfig.resolveConfig(mockReporter)).pollingTimeout).toStrictEqual(1)
     })
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   junit_report:
     required: false
     description: 'The filename for a JUnit report if you want to generate one.'
+  polling_timeout:
+    required: false
+    description: The duration (in milliseconds) after which the orb stops polling for test results.
 
 runs:
   using: 'node16'

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
     description: 'The filename for a JUnit report if you want to generate one.'
   polling_timeout:
     required: false
-    description: The duration (in milliseconds) after which the orb stops polling for test results.
+    description: 'The duration (in milliseconds) after which the action stops polling for test results.'
 
 runs:
   using: 'node16'

--- a/src/resolve-config.ts
+++ b/src/resolve-config.ts
@@ -45,6 +45,7 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
     ?.split(',')
     .map((variableString: string) => variableString.trim())
   const tunnel = getDefinedBoolean('tunnel')
+  const pollingTimeout = getDefinedInteger('polling_timeout')
 
   let config = JSON.parse(JSON.stringify(DEFAULT_CONFIG))
   // Override with file config variables
@@ -55,7 +56,7 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
     })
   } catch (error) {
     if (configPath) {
-      core.setFailed(`Unable to parse config file! Please verify config path : ${configPath}`)
+      core.setFailed(`Unable to parse config file! Please verify config path: ${configPath}`)
       throw error
     }
     // Here, if configPath is not present it means that default config file does not exist: in this case it's expected for the github action to be silent.
@@ -70,6 +71,7 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
       configPath,
       datadogSite,
       files,
+      pollingTimeout,
       publicIds,
       subdomain,
       testSearchQuery,
@@ -102,6 +104,22 @@ export const getDefinedBoolean = (name: string): boolean | undefined => {
     core.setFailed(String(error))
     throw error
   }
+}
+
+export const getDefinedInteger = (name: string): number | undefined => {
+  const input = getDefinedInput(name)
+  if (!input) {
+    return undefined
+  }
+
+  const number = parseFloat(input)
+  if (!Number.isInteger(number)) {
+    const error = Error(`${number} is not an integer`)
+    core.setFailed(error)
+    throw error
+  }
+
+  return number
 }
 
 export const getReporter = (): synthetics.MainReporter => {

--- a/src/resolve-config.ts
+++ b/src/resolve-config.ts
@@ -114,7 +114,7 @@ export const getDefinedInteger = (name: string): number | undefined => {
 
   const number = parseFloat(input)
   if (!Number.isInteger(number)) {
-    const error = Error(`${number} is not an integer`)
+    const error = Error(`Invalid value for ${name}: ${number} is not an integer`)
     core.setFailed(error)
     throw error
   }


### PR DESCRIPTION
This PR adds a `polling_timeout` input to be able to set a value of `pollingTimeout` different than the default of 30 minutes ([official documentation](https://docs.datadoghq.com/continuous_testing/cicd_integrations/configuration?tab=npm#global-configuration-file-options)).

This input must be an integer.