### PR TITLE
Use default command config exported by datadog-ci

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -29,18 +29,11 @@ describe('Run Github Action', () => {
   })
   describe('Handle input parameters', () => {
     test('Github Action called with dummy parameter fails with core.setFailed', async () => {
-      const originalResolveConfig = resolveConfigModule.resolveConfig
-      jest.spyOn(resolveConfigModule, 'resolveConfig').mockImplementation(async reporter => ({
-        ...(await originalResolveConfig(reporter)),
-        failOnCriticalErrors: true,
-      }))
-
       const setFailedMock = jest.spyOn(core, 'setFailed')
-
+      synthetics.DEFAULT_COMMAND_CONFIG.failOnCriticalErrors = true
       await run()
-
+      synthetics.DEFAULT_COMMAND_CONFIG.failOnCriticalErrors = false
       expect(setFailedMock).toHaveBeenCalledWith('Running Datadog Synthetics tests failed.')
-      expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('Credentials refused'))
     })
 
     test('Github Action core.getInput parameters are passed on to runTests', async () => {

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -29,11 +29,18 @@ describe('Run Github Action', () => {
   })
   describe('Handle input parameters', () => {
     test('Github Action called with dummy parameter fails with core.setFailed', async () => {
+      const originalResolveConfig = resolveConfigModule.resolveConfig
+      jest.spyOn(resolveConfigModule, 'resolveConfig').mockImplementation(async reporter => ({
+        ...(await originalResolveConfig(reporter)),
+        failOnCriticalErrors: true,
+      }))
+
       const setFailedMock = jest.spyOn(core, 'setFailed')
-      resolveConfigModule.DEFAULT_CONFIG.failOnCriticalErrors = true
+
       await run()
-      resolveConfigModule.DEFAULT_CONFIG.failOnCriticalErrors = false
+
       expect(setFailedMock).toHaveBeenCalledWith('Running Datadog Synthetics tests failed.')
+      expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('Credentials refused'))
     })
 
     test('Github Action core.getInput parameters are passed on to runTests', async () => {

--- a/src/resolve-config.ts
+++ b/src/resolve-config.ts
@@ -2,25 +2,6 @@ import * as core from '@actions/core'
 import {synthetics, utils} from '@datadog/datadog-ci'
 import deepExtend from 'deep-extend'
 
-export const DEFAULT_CONFIG: synthetics.CommandConfig = {
-  apiKey: '',
-  appKey: '',
-  configPath: 'datadog-ci.json',
-  datadogSite: 'datadoghq.com',
-  failOnCriticalErrors: false,
-  failOnMissingTests: false,
-  failOnTimeout: true,
-  files: ['{,!(node_modules)/**/}*.synthetics.json'],
-  global: {},
-  locations: [],
-  pollingTimeout: 30 * 60 * 1000,
-  proxy: {protocol: 'http'},
-  publicIds: [],
-  subdomain: 'app',
-  tunnel: false,
-  variableStrings: [],
-}
-
 export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<synthetics.CommandConfig> => {
   let apiKey
   let appKey
@@ -47,12 +28,12 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
   const tunnel = getDefinedBoolean('tunnel')
   const pollingTimeout = getDefinedInteger('polling_timeout')
 
-  let config = JSON.parse(JSON.stringify(DEFAULT_CONFIG))
+  let config = JSON.parse(JSON.stringify(synthetics.DEFAULT_COMMAND_CONFIG))
   // Override with file config variables
   try {
     config = await utils.resolveConfigFromFile(config, {
       configPath,
-      defaultConfigPaths: [DEFAULT_CONFIG.configPath],
+      defaultConfigPaths: [synthetics.DEFAULT_COMMAND_CONFIG.configPath],
     })
   } catch (error) {
     if (configPath) {


### PR DESCRIPTION
Following https://github.com/DataDog/datadog-ci/pull/887, `DEFAULT_COMMAND_CONFIG` is now exported by datadog-ci.

This PR replaces this integration's local default config, with a usage of `synthetics.DEFAULT_COMMAND_CONFIG`.

It also updates one unit test, because we don't have a `DEFAULT_CONFIG` object anymore.