### PR TITLE
[ci] Update config files

### DIFF
--- a/.github/workflows/e2e/global.config.json
+++ b/.github/workflows/e2e/global.config.json
@@ -1,6 +1,8 @@
 {
   "global": {
-    "headers": {"X-Fake-Header": "fake value"}
-  },
-  "timeout": 240000
+    "headers": {
+      "X-Fake-Header": "fake value"
+    },
+    "pollingTimeout": 240000
+  }
 }


### PR DESCRIPTION
The `timeout` option was removed a long time ago (cf. [here](https://github.com/DataDog/datadog-ci/blob/aed788742c95396eb3c898799dd64c712df2edb2/src/commands/synthetics/README.md) and [here](https://github.com/DataDog/datadog-ci/blob/aed788742c95396eb3c898799dd64c712df2edb2/src/commands/synthetics/run-test.ts#L58) to go back in time).

This PR updates the config to [the right  `pollingTimeout` config](https://github.com/DataDog/datadog-ci/blob/c6ce9dcf152521adb118c15b75434f645e22ab6a/src/commands/synthetics/run-test.ts#L156).