### PR TITLE
[SYNTH-9893] move polling_timeout input to the global config field

### DIFF
--- a/__tests__/resolve-config.test.ts
+++ b/__tests__/resolve-config.test.ts
@@ -107,8 +107,14 @@ describe('Resolves Config', () => {
   })
 
   describe('parses integer', () => {
+    // datadog-ci pushes pollingTimeout from root config to global config if pollingTimeout is undefined in the global config
+    // the implementation: https://github.com/DataDog/datadog-ci/blob/8000318d70fd8af22b0e377b27078762b562efb7/src/commands/synthetics/command.ts#L228
+    // the test: https://github.com/DataDog/datadog-ci/blob/65ffde5d90474af5930da4c2faf016505b70bff9/src/commands/synthetics/__tests__/cli.test.ts#L173-L186
+
     test('falls back to default if input is not set', async () => {
       expect(resolveConfig.getDefinedInteger('polling_timeout')).toBeUndefined()
+      // datadog-ci overrides global.pollingTimeout with pollingTimeout if the former is undefined, see comment above
+      expect((await resolveConfig.resolveConfig(mockReporter)).global.pollingTimeout).toBeUndefined()
       expect((await resolveConfig.resolveConfig(mockReporter)).pollingTimeout).toStrictEqual(30 * 60 * 1000)
     })
 
@@ -118,6 +124,8 @@ describe('Resolves Config', () => {
         INPUT_POLLING_TIMEOUT: '',
       }
       expect(resolveConfig.getDefinedInteger('polling_timeout')).toBeUndefined()
+      // datadog-ci overrides global.pollingTimeout with pollingTimeout if the former is undefined, see comment above
+      expect((await resolveConfig.resolveConfig(mockReporter)).global.pollingTimeout).toBeUndefined()
       expect((await resolveConfig.resolveConfig(mockReporter)).pollingTimeout).toStrictEqual(30 * 60 * 1000)
     })
 
@@ -134,7 +142,7 @@ describe('Resolves Config', () => {
         ...process.env,
         INPUT_POLLING_TIMEOUT: '1',
       }
-      expect((await resolveConfig.resolveConfig(mockReporter)).pollingTimeout).toStrictEqual(1)
+      expect((await resolveConfig.resolveConfig(mockReporter)).global.pollingTimeout).toStrictEqual(1)
     })
   })
 })

--- a/src/resolve-config.ts
+++ b/src/resolve-config.ts
@@ -52,7 +52,6 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
       configPath,
       datadogSite,
       files,
-      pollingTimeout,
       publicIds,
       subdomain,
       testSearchQuery,
@@ -60,6 +59,7 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
       global: deepExtend(
         config.global,
         utils.removeUndefinedValues({
+          pollingTimeout,
           variables: synthetics.utils.parseVariablesFromCli(variableStrings, reporter.log.bind(reporter)),
         })
       ),


### PR DESCRIPTION
This PR moves the `polling_timeout` input from the root of the config to the `global` field of the config, where it's expected by datadog-ci: 
datadog-ci pushes pollingTimeout from root config to global config if pollingTimeout is undefined in the global config
- the implementation: https://github.com/DataDog/datadog-ci/blob/8000318d70fd8af22b0e377b27078762b562efb7/src/commands/synthetics/command.ts#L228
- the test: https://github.com/DataDog/datadog-ci/blob/65ffde5d90474af5930da4c2faf016505b70bff9/src/commands/synthetics/__tests__/cli.test.ts#L173-L186