### PR TITLE
[SYNTH-9893] populate both pollingTimeout in config

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -43,6 +43,10 @@ describe('Run Github Action', () => {
       expect(synthetics.executeTests).toHaveBeenCalledWith(expect.anything(), {
         ...config,
         ...inputs,
+        global: {
+          ...config.global,
+          pollingTimeout: config.pollingTimeout,
+        },
       })
     })
 
@@ -58,6 +62,10 @@ describe('Run Github Action', () => {
       expect(synthetics.executeTests).toHaveBeenCalledWith(expect.anything(), {
         ...config,
         ...inputs,
+        global: {
+          ...config.global,
+          pollingTimeout: config.pollingTimeout,
+        },
         publicIds,
       })
     })
@@ -75,6 +83,8 @@ describe('Run Github Action', () => {
         ...config,
         ...inputs,
         global: {
+          ...config.global,
+          pollingTimeout: config.pollingTimeout,
           variables: {
             START_URL: 'https://example.org',
             MY_VARIABLE: 'My title',
@@ -100,6 +110,10 @@ describe('Run Github Action', () => {
       expect(synthetics.executeTests).toHaveBeenCalledWith(expect.anything(), {
         ...config,
         ...inputs,
+        global: {
+          ...config.global,
+          pollingTimeout: config.pollingTimeout,
+        },
       })
 
       expect(fs.existsSync('./reports/TEST-1.xml')).toBe(true)
@@ -120,6 +134,10 @@ describe('Run Github Action', () => {
         ...config,
         ...inputs,
         datadogSite: 'datadoghq.com',
+        global: {
+          ...config.global,
+          pollingTimeout: config.pollingTimeout,
+        },
       })
     })
   })

--- a/__tests__/resolve-config.test.ts
+++ b/__tests__/resolve-config.test.ts
@@ -47,12 +47,23 @@ describe('Resolves Config', () => {
       ...config,
       ...requiredInputs,
       files: ['foobar.synthetics.json'],
+      global: {
+        ...config.global,
+        pollingTimeout: config.pollingTimeout,
+      },
     })
   })
 
   test('Default configuration applied if global configuration empty', async () => {
     jest.spyOn(fs, 'existsSync').mockImplementation(() => false)
-    await expect(resolveConfig.resolveConfig(mockReporter)).resolves.toStrictEqual({...config, ...requiredInputs})
+    await expect(resolveConfig.resolveConfig(mockReporter)).resolves.toStrictEqual({
+      ...config,
+      ...requiredInputs,
+      global: {
+        ...config.global,
+        pollingTimeout: config.pollingTimeout,
+      },
+    })
   })
 
   test('Variable strings input set in the config when defined', async () => {
@@ -65,6 +76,8 @@ describe('Resolves Config', () => {
       ...config,
       ...requiredInputs,
       global: {
+        ...config.global,
+        pollingTimeout: config.pollingTimeout,
         variables: {START_URL: 'https://example.org', MY_VARIABLE: 'My title'},
       },
     })
@@ -74,6 +87,10 @@ describe('Resolves Config', () => {
     await expect(resolveConfig.resolveConfig(mockReporter)).resolves.toStrictEqual({
       ...config,
       ...requiredInputs,
+      global: {
+        ...config.global,
+        pollingTimeout: config.pollingTimeout,
+      },
     })
   })
 
@@ -107,15 +124,9 @@ describe('Resolves Config', () => {
   })
 
   describe('parses integer', () => {
-    // datadog-ci pushes pollingTimeout from root config to global config if pollingTimeout is undefined in the global config
-    // the implementation: https://github.com/DataDog/datadog-ci/blob/8000318d70fd8af22b0e377b27078762b562efb7/src/commands/synthetics/command.ts#L228
-    // the test: https://github.com/DataDog/datadog-ci/blob/65ffde5d90474af5930da4c2faf016505b70bff9/src/commands/synthetics/__tests__/cli.test.ts#L173-L186
-
     test('falls back to default if input is not set', async () => {
       expect(resolveConfig.getDefinedInteger('polling_timeout')).toBeUndefined()
-      // datadog-ci overrides global.pollingTimeout with pollingTimeout if the former is undefined, see comment above
-      expect((await resolveConfig.resolveConfig(mockReporter)).global.pollingTimeout).toBeUndefined()
-      expect((await resolveConfig.resolveConfig(mockReporter)).pollingTimeout).toStrictEqual(30 * 60 * 1000)
+      expect((await resolveConfig.resolveConfig(mockReporter)).global.pollingTimeout).toStrictEqual(30 * 60 * 1000)
     })
 
     test('falls back to default if input is an empty value', async () => {
@@ -124,9 +135,7 @@ describe('Resolves Config', () => {
         INPUT_POLLING_TIMEOUT: '',
       }
       expect(resolveConfig.getDefinedInteger('polling_timeout')).toBeUndefined()
-      // datadog-ci overrides global.pollingTimeout with pollingTimeout if the former is undefined, see comment above
-      expect((await resolveConfig.resolveConfig(mockReporter)).global.pollingTimeout).toBeUndefined()
-      expect((await resolveConfig.resolveConfig(mockReporter)).pollingTimeout).toStrictEqual(30 * 60 * 1000)
+      expect((await resolveConfig.resolveConfig(mockReporter)).global.pollingTimeout).toStrictEqual(30 * 60 * 1000)
     })
 
     test('throws if input is a float', async () => {

--- a/src/resolve-config.ts
+++ b/src/resolve-config.ts
@@ -52,6 +52,7 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
       configPath,
       datadogSite,
       files,
+      pollingTimeout,
       publicIds,
       subdomain,
       testSearchQuery,
@@ -65,6 +66,9 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
       ),
     })
   )
+
+  // Pass root polling timeout to global override to get it applied to all tests if not defined individually
+  config.global.pollingTimeout = config.global.pollingTimeout ?? config.pollingTimeout
 
   return config
 }


### PR DESCRIPTION
Following https://github.com/DataDog/synthetics-ci-github-action/pull/155, we eventually found that the solution wasn't satisfactory: both the `config.pollingTimeout` and `config.global.pollingTimeout` should be populated.

`config.pollingTimeout` is used to compute the `maxPollingTimeout` used by datadog-ci to wait for the batch result, but is never sent to the API: https://github.com/DataDog/datadog-ci/blob/1e7a4ae91d25a52434af622ceda1556c06b1c397/src/commands/synthetics/run-test.ts#L148

`config.global.pollingTimeout` overrides the `pollingTimeout` individually in tests, which is used by the API to know when a batch times out: https://github.com/DataDog/datadog-ci/blob/1e7a4ae91d25a52434af622ceda1556c06b1c397/src/commands/synthetics/run-test.ts#L50-L53