### PR TITLE
Add newlines before success message

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -211,7 +211,7 @@ describe('Run Github Action', () => {
       await run()
       expect(setFailedMock).not.toHaveBeenCalled()
       expect(infoMock).toHaveBeenCalledWith(
-        `Datadog Synthetics tests succeeded: criticalErrors: 0, passed: 0, failedNonBlocking: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 1\n` +
+        `\n\nDatadog Synthetics tests succeeded: criticalErrors: 0, passed: 0, failedNonBlocking: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 1\n` +
           `Results URL: https://app.datadoghq.com/synthetics/explorer/ci?batchResultId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa`
       )
     })
@@ -226,7 +226,7 @@ describe('Run Github Action', () => {
 
       await run()
       expect(infoMock).toHaveBeenCalledWith(
-        `Datadog Synthetics tests succeeded: criticalErrors: 0, passed: 0, failedNonBlocking: 0, failed: 0, skipped: 0, notFound: 1, timedOut: 0\n` +
+        `\n\nDatadog Synthetics tests succeeded: criticalErrors: 0, passed: 0, failedNonBlocking: 0, failed: 0, skipped: 0, notFound: 1, timedOut: 0\n` +
           `Results URL: https://app.datadoghq.com/synthetics/explorer/ci?batchResultId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa`
       )
     })

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ const run = async (): Promise<void> => {
     if (exitReason !== 'passed') {
       core.setFailed(`Datadog Synthetics tests failed: ${printSummary(summary, config)}`)
     } else {
-      core.info(`Datadog Synthetics tests succeeded: ${printSummary(summary, config)}`)
+      core.info(`\n\nDatadog Synthetics tests succeeded: ${printSummary(summary, config)}`)
     }
   } catch (error) {
     synthetics.utils.reportExitLogs(reporter, config, {error})


### PR DESCRIPTION
Currently, some newlines are missing between the summary and the success message.

Notice the `Total Duration: 16sDatadog Synthetics tests succeeded`:

![image](https://github.com/DataDog/synthetics-ci-github-action/assets/9317502/09f691a7-c55a-4282-b4a0-665c92efd3c6)

After this PR:

![image](https://github.com/DataDog/synthetics-ci-github-action/assets/9317502/fd39d0c8-dced-4528-9640-e7acd00aa6e6)

While `core.info()` is just a wrapper for `process.stdout.write(message + os.EOL)`, `core.setFailed()` issues [an error command](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message), which is displayed differently so we don't need to add newlines for this function:

![image](https://github.com/DataDog/synthetics-ci-github-action/assets/9317502/7843387d-f5e4-43e6-b1d8-eecd8b9236cb)
