### PR TITLE
[dep] Upgrade `@vercel/ncc`

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,3 +19,4 @@ jobs:
       - run: yarn build
       - run: yarn lint
       - run: yarn test
+      - run: yarn package # Ensure `ncc` works

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/jest": "^29.5.8",
     "@types/node": "^20.11.13",
     "@typescript-eslint/parser": "^5.3.0",
-    "@vercel/ncc": "^0.31.1",
+    "@vercel/ncc": "^0.38.1",
     "eslint": "^8.39.0",
     "eslint-plugin-github": "^4.3.2",
     "eslint-plugin-jest": "^25.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3124,14 +3124,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/ncc@npm:^0.31.1":
-  version: 0.31.1
-  resolution: "@vercel/ncc@npm:0.31.1"
+"@vercel/ncc@npm:^0.38.1":
+  version: 0.38.1
+  resolution: "@vercel/ncc@npm:0.38.1"
   dependencies:
     node-gyp: latest
   bin:
     ncc: dist/ncc/cli.js
-  checksum: 296151a9e67b211b265db11bbbb3be6690833a890629da07d58655d916aa6bd6319b508d14fb2f0d027f59cdf8eb5b76e352ac1d2c77f5d106b940a9d144962a
+  checksum: a522bb44c25a65db89941b08ca5817794b6920052f09a9cbd202cc987b81c13dd48cad9aa3b06793fc47ef70ae87fa0b85caf5b6a73e95de8091818049ed6194
   languageName: node
   linkType: hard
 
@@ -4038,7 +4038,7 @@ __metadata:
     "@types/jest": ^29.5.8
     "@types/node": ^20.11.13
     "@typescript-eslint/parser": ^5.3.0
-    "@vercel/ncc": ^0.31.1
+    "@vercel/ncc": ^0.38.1
     deep-extend: 0.6.0
     eslint: ^8.39.0
     eslint-plugin-github: ^4.3.2


### PR DESCRIPTION
Fixes [the following issue](https://github.com/DataDog/synthetics-ci-github-action/actions/runs/7873214387/job/21480049366) when doing `yarn package`:

```js
ncc: Version 0.31.1
ncc: Compiling file index.js into CJS
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:68:1[9](https://github.com/DataDog/synthetics-ci-github-action/actions/runs/7873214387/job/21480049366#step:9:10))
    at Object.createHash (node:crypto:138:[10](https://github.com/DataDog/synthetics-ci-github-action/actions/runs/7873214387/job/21480049366#step:9:11))
    at hashOf (/home/runner/work/synthetics-ci-github-action/synthetics-ci-github-action/node_modules/@vercel/ncc/dist/ncc/index.js.cache.js:37:1855992)
    at ncc (/home/runner/work/synthetics-ci-github-action/synthetics-ci-github-action/node_modules/@vercel/ncc/dist/ncc/index.js.cache.js:37:1860457)
    at runCmd (/home/runner/work/synthetics-ci-github-action/synthetics-ci-github-action/node_modules/@vercel/ncc/dist/ncc/cli.js.cache.js:1:55[12](https://github.com/DataDog/synthetics-ci-github-action/actions/runs/7873214387/job/21480049366#step:9:13)8)
    at 819 (/home/runner/work/synthetics-ci-github-action/synthetics-ci-github-action/node_modules/@vercel/ncc/dist/ncc/cli.js.cache.js:1:5[16](https://github.com/DataDog/synthetics-ci-github-action/actions/runs/7873214387/job/21480049366#step:9:17)98)
    at __webpack_require__ (/home/runner/work/synthetics-ci-github-action/synthetics-ci-github-action/node_modules/@vercel/ncc/dist/ncc/cli.js.cache.js:1:59048)
    at /home/runner/work/synthetics-ci-github-action/synthetics-ci-github-action/node_modules/@vercel/ncc/dist/ncc/cli.js.cache.js:1:59260
    at /home/runner/work/synthetics-ci-github-action/synthetics-ci-github-action/node_modules/@vercel/ncc/dist/ncc/cli.js.cache.js:1:59321
    at Object.<anonymous> (/home/runner/work/synthetics-ci-github-action/synthetics-ci-github-action/node_modules/@vercel/ncc/dist/ncc/cli.js:8:28) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```

Related to https://github.com/vercel/ncc/issues/1012