### PR TITLE
Remove usage of deprecated `global`

### DIFF
--- a/.github/workflows/e2e/global.config.json
+++ b/.github/workflows/e2e/global.config.json
@@ -1,5 +1,5 @@
 {
-  "global": {
+  "defaultTestOverrides": {
     "headers": {
       "X-Fake-Header": "fake value"
     },

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ jobs:
           variables: 'START_URL=https://staging.website.com,PASSWORD=stagingpassword'
 ```
 
-### Example workflow using a global configuration override with `config_path`
+### Example workflow using a global configuration file with `config_path`
 
-This GitHub Action overrides the path to the global `datadog-ci.config.json` file.
+By default, the path to the global configuration file is `datadog-ci.json`. You can override this path with the `config_path` input.
 
 ```yaml
 name: Run Synthetic tests with custom config
@@ -110,10 +110,10 @@ jobs:
         with:
           api_key: ${{secrets.DD_API_KEY}}
           app_key: ${{secrets.DD_APP_KEY}}
-          config_path: './synthetics-config.json'
+          config_path: './global.config.json'
 ```
 
-For an example test file, see this [`global.config.json` file][13].
+For an example of global configuration file, see this [`global.config.json` file][13].
 
 ## Inputs
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -53,8 +53,8 @@ describe('Run Github Action', () => {
       expect(synthetics.executeTests).toHaveBeenCalledWith(expect.anything(), {
         ...config,
         ...inputs,
-        global: {
-          ...config.global,
+        defaultTestOverrides: {
+          ...config.defaultTestOverrides,
           pollingTimeout: config.pollingTimeout,
         },
       })
@@ -72,8 +72,8 @@ describe('Run Github Action', () => {
       expect(synthetics.executeTests).toHaveBeenCalledWith(expect.anything(), {
         ...config,
         ...inputs,
-        global: {
-          ...config.global,
+        defaultTestOverrides: {
+          ...config.defaultTestOverrides,
           pollingTimeout: config.pollingTimeout,
         },
         publicIds,
@@ -92,8 +92,8 @@ describe('Run Github Action', () => {
       expect(synthetics.executeTests).toHaveBeenCalledWith(expect.anything(), {
         ...config,
         ...inputs,
-        global: {
-          ...config.global,
+        defaultTestOverrides: {
+          ...config.defaultTestOverrides,
           pollingTimeout: config.pollingTimeout,
           variables: {
             START_URL: 'https://example.org',
@@ -120,8 +120,8 @@ describe('Run Github Action', () => {
       expect(synthetics.executeTests).toHaveBeenCalledWith(expect.anything(), {
         ...config,
         ...inputs,
-        global: {
-          ...config.global,
+        defaultTestOverrides: {
+          ...config.defaultTestOverrides,
           pollingTimeout: config.pollingTimeout,
         },
       })
@@ -144,8 +144,8 @@ describe('Run Github Action', () => {
         ...config,
         ...inputs,
         datadogSite: 'datadoghq.com',
-        global: {
-          ...config.global,
+        defaultTestOverrides: {
+          ...config.defaultTestOverrides,
           pollingTimeout: config.pollingTimeout,
         },
       })

--- a/__tests__/resolve-config.test.ts
+++ b/__tests__/resolve-config.test.ts
@@ -45,26 +45,29 @@ describe('Resolves Config', () => {
     ) => {
       callback(null, Buffer.from(JSON.stringify({files: ['foobar.synthetics.json']})))
     }) as typeof fs.readFile
+
     jest.spyOn(fs, 'existsSync').mockImplementation(() => true)
     jest.spyOn(fs, 'readFile').mockImplementation(fakeReadFile)
+
     await expect(resolveConfig.resolveConfig(mockReporter)).resolves.toStrictEqual({
       ...config,
       ...requiredInputs,
       files: ['foobar.synthetics.json'],
-      global: {
-        ...config.global,
+      defaultTestOverrides: {
+        ...config.defaultTestOverrides,
         pollingTimeout: config.pollingTimeout,
       },
     })
   })
 
-  test('Default configuration applied if global configuration empty', async () => {
+  test('Default configuration applied if global configuration is empty', async () => {
     jest.spyOn(fs, 'existsSync').mockImplementation(() => false)
+
     await expect(resolveConfig.resolveConfig(mockReporter)).resolves.toStrictEqual({
       ...config,
       ...requiredInputs,
-      global: {
-        ...config.global,
+      defaultTestOverrides: {
+        ...config.defaultTestOverrides,
         pollingTimeout: config.pollingTimeout,
       },
     })
@@ -79,8 +82,8 @@ describe('Resolves Config', () => {
     await expect(resolveConfig.resolveConfig(mockReporter)).resolves.toStrictEqual({
       ...config,
       ...requiredInputs,
-      global: {
-        ...config.global,
+      defaultTestOverrides: {
+        ...config.defaultTestOverrides,
         pollingTimeout: config.pollingTimeout,
         variables: {START_URL: 'https://example.org', MY_VARIABLE: 'My title'},
       },
@@ -91,8 +94,8 @@ describe('Resolves Config', () => {
     await expect(resolveConfig.resolveConfig(mockReporter)).resolves.toStrictEqual({
       ...config,
       ...requiredInputs,
-      global: {
-        ...config.global,
+      defaultTestOverrides: {
+        ...config.defaultTestOverrides,
         pollingTimeout: config.pollingTimeout,
       },
     })
@@ -130,7 +133,9 @@ describe('Resolves Config', () => {
   describe('parses integer', () => {
     test('falls back to default if input is not set', async () => {
       expect(resolveConfig.getDefinedInteger('polling_timeout')).toBeUndefined()
-      expect((await resolveConfig.resolveConfig(mockReporter)).global.pollingTimeout).toStrictEqual(30 * 60 * 1000)
+      expect((await resolveConfig.resolveConfig(mockReporter)).defaultTestOverrides?.pollingTimeout).toStrictEqual(
+        30 * 60 * 1000
+      )
     })
 
     test('falls back to default if input is an empty value', async () => {
@@ -139,7 +144,9 @@ describe('Resolves Config', () => {
         INPUT_POLLING_TIMEOUT: '',
       }
       expect(resolveConfig.getDefinedInteger('polling_timeout')).toBeUndefined()
-      expect((await resolveConfig.resolveConfig(mockReporter)).global.pollingTimeout).toStrictEqual(30 * 60 * 1000)
+      expect((await resolveConfig.resolveConfig(mockReporter)).defaultTestOverrides?.pollingTimeout).toStrictEqual(
+        30 * 60 * 1000
+      )
     })
 
     test('throws if input is a float', async () => {
@@ -155,7 +162,7 @@ describe('Resolves Config', () => {
         ...process.env,
         INPUT_POLLING_TIMEOUT: '1',
       }
-      expect((await resolveConfig.resolveConfig(mockReporter)).global.pollingTimeout).toStrictEqual(1)
+      expect((await resolveConfig.resolveConfig(mockReporter)).defaultTestOverrides?.pollingTimeout).toStrictEqual(1)
     })
   })
 })

--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -5,6 +5,7 @@ export const config: synthetics.RunTestsCommandConfig = {
   appKey: '',
   configPath: 'datadog-ci.json',
   datadogSite: 'datadoghq.com',
+  defaultTestOverrides: {},
   failOnCriticalErrors: false,
   failOnMissingTests: false,
   failOnTimeout: true,

--- a/src/resolve-config.ts
+++ b/src/resolve-config.ts
@@ -54,6 +54,13 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
       appKey,
       configPath,
       datadogSite,
+      defaultTestOverrides: deepExtend(
+        config.defaultTestOverrides,
+        utils.removeUndefinedValues({
+          pollingTimeout,
+          variables: synthetics.utils.parseVariablesFromCli(variableStrings, reporter.log.bind(reporter)),
+        })
+      ),
       failOnCriticalErrors,
       failOnMissingTests,
       failOnTimeout,
@@ -63,18 +70,11 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
       subdomain,
       testSearchQuery,
       tunnel,
-      global: deepExtend(
-        config.global,
-        utils.removeUndefinedValues({
-          pollingTimeout,
-          variables: synthetics.utils.parseVariablesFromCli(variableStrings, reporter.log.bind(reporter)),
-        })
-      ),
     })
   )
 
   // Pass root polling timeout to global override to get it applied to all tests if not defined individually
-  config.global.pollingTimeout = config.global.pollingTimeout ?? config.pollingTimeout
+  config.defaultTestOverrides.pollingTimeout = config.defaultTestOverrides.pollingTimeout ?? config.pollingTimeout
 
   return config
 }

--- a/src/resolve-config.ts
+++ b/src/resolve-config.ts
@@ -73,7 +73,7 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
     })
   )
 
-  // Pass root polling timeout to global override to get it applied to all tests if not defined individually
+  // Pass root polling timeout to default test overrides to get it applied to all tests if not defined individually
   config.defaultTestOverrides.pollingTimeout = config.defaultTestOverrides.pollingTimeout ?? config.pollingTimeout
 
   return config


### PR DESCRIPTION
See https://github.com/DataDog/datadog-ci/pull/1285