### PR TITLE
docs(readme): update examples with latest checkout action version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Datadog Synthetic tests
         uses: DataDog/synthetics-ci-github-action@v2.1.0
         with:
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Datadog Synthetic tests
         uses: DataDog/synthetics-ci-github-action@v2.1.0
         with:
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Datadog Synthetic tests
         uses: DataDog/synthetics-ci-github-action@v2.1.0
         with:
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Datadog Synthetic tests
         uses: DataDog/synthetics-ci-github-action@v2.1.0
         with:
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Datadog Synthetic tests
         uses: DataDog/synthetics-ci-github-action@v2.1.0
         with:


### PR DESCRIPTION
Update `actions/checkout@v3` to `actions/checkout@v4`