### PR TITLE
Remove redundant newlines in success output

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -198,7 +198,7 @@ describe('Run Github Action', () => {
       await run()
       expect(setFailedMock).not.toHaveBeenCalled()
       expect(infoMock).toHaveBeenCalledWith(
-        `\n\nDatadog Synthetics tests succeeded: criticalErrors: 0, passed: 0, failedNonBlocking: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 1\n` +
+        `Datadog Synthetics tests succeeded: criticalErrors: 0, passed: 0, failedNonBlocking: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 1\n` +
           `Results URL: https://app.datadoghq.com/synthetics/explorer/ci?batchResultId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa`
       )
     })
@@ -213,7 +213,7 @@ describe('Run Github Action', () => {
 
       await run()
       expect(infoMock).toHaveBeenCalledWith(
-        `\n\nDatadog Synthetics tests succeeded: criticalErrors: 0, passed: 0, failedNonBlocking: 0, failed: 0, skipped: 0, notFound: 1, timedOut: 0\n` +
+        `Datadog Synthetics tests succeeded: criticalErrors: 0, passed: 0, failedNonBlocking: 0, failed: 0, skipped: 0, notFound: 1, timedOut: 0\n` +
           `Results URL: https://app.datadoghq.com/synthetics/explorer/ci?batchResultId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa`
       )
     })

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ const run = async (): Promise<void> => {
     if (exitReason !== 'passed') {
       core.setFailed(`Datadog Synthetics tests failed: ${printSummary(summary, config)}`)
     } else {
-      core.info(`\n\nDatadog Synthetics tests succeeded: ${printSummary(summary, config)}`)
+      core.info(`Datadog Synthetics tests succeeded: ${printSummary(summary, config)}`)
     }
   } catch (error) {
     synthetics.utils.reportExitLogs(reporter, config, {error})


### PR DESCRIPTION

This PR reverts https://github.com/DataDog/synthetics-ci-github-action/pull/162 because there is no reason to do it anymore:

<img width="1064" alt="image" src="https://github.com/user-attachments/assets/6221b929-acbd-4fa8-92aa-27178c735828" />
