### PR TITLE
Add error message to inform about new input format

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -23,10 +23,10 @@ jobs:
         env:
           FORCE_COLOR: 1
         with:
-          api-key: ${{ secrets.datadog_api_key }}
-          app-key: ${{ secrets.datadog_app_key }}
-          config-path: './.github/workflows/e2e/global.config.json'
-          public-ids: |
+          api_key: ${{ secrets.datadog_api_key }}
+          app_key: ${{ secrets.datadog_app_key }}
+          config_path: './.github/workflows/e2e/global.config.json'
+          public_ids: |
             pwd-mwg-3p5
             2r9-q7u-4nn
       - name: Example of using outputs

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -23,10 +23,10 @@ jobs:
         env:
           FORCE_COLOR: 1
         with:
-          api_key: ${{ secrets.datadog_api_key }}
-          app_key: ${{ secrets.datadog_app_key }}
-          config_path: './.github/workflows/e2e/global.config.json'
-          public_ids: |
+          api-key: ${{ secrets.datadog_api_key }}
+          app-key: ${{ secrets.datadog_app_key }}
+          config-path: './.github/workflows/e2e/global.config.json'
+          public-ids: |
             pwd-mwg-3p5
             2r9-q7u-4nn
       - name: Example of using outputs

--- a/src/resolve-config.ts
+++ b/src/resolve-config.ts
@@ -10,6 +10,13 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
     apiKey = core.getInput('api-key', {required: true})
     appKey = core.getInput('app-key', {required: true})
   } catch (error) {
+    if (core.getInput('api_key') || core.getInput('app_key')) {
+      core.setFailed(
+        "We renamed all inputs from snake_case to kebab-case in version 3.0.0 to follow GitHub's convention. Please update your workflow to use the new inputs."
+      )
+      throw error
+    }
+
     core.setFailed('Missing API or APP keys to initialize datadog-ci!')
     throw error
   }


### PR DESCRIPTION
After #316, we need to inform users.

The warning was already provided by GitHub. This PR adds an error message.

![image](https://github.com/user-attachments/assets/71e67dea-3575-4b76-91c3-23a622723e9e)
