### PR TITLE
[SINT-4280] prepare dd-octo-sts policies

### DIFF
--- a/.github/chainguard/self.bump-datadog-ci.create-pr.sts.yaml
+++ b/.github/chainguard/self.bump-datadog-ci.create-pr.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/synthetics-ci-github-action:ref:refs/heads/main
+
+claim_pattern:
+  event_name: workflow_dispatch
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/synthetics-ci-github-action/\.github/workflows/bump-datadog-ci\.yml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/chainguard/self.release-version-on-merge.create-release.sts.yaml
+++ b/.github/chainguard/self.release-version-on-merge.create-release.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/synthetics-ci-github-action:ref:refs/heads/main
+claim_pattern:
+  event_name: pull_request
+  ref: refs/heads/main
+  job_workflow_ref: DataDog/synthetics-ci-github-action/\.github/workflows/release-version-on-merge\.yml@.*
+
+permissions:
+  contents: write

--- a/.github/chainguard/self.release-version.create-pr.sts.yaml
+++ b/.github/chainguard/self.release-version.create-pr.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/synthetics-ci-github-action:ref:refs/heads/main
+
+claim_pattern:
+  event_name: workflow_dispatch
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/synthetics-ci-github-action/\.github/workflows/release-version\.yml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Overview
- 
+
 ![GitHub Release](https://img.shields.io/github/v/release/DataDog/synthetics-ci-github-action)
 
 Trigger Datadog Synthetic tests from your GitHub workflows.


### PR DESCRIPTION
This PR prepares the repository to use [dd-octo-sts](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts) instead of a Github app needed secrets.
The policies provisioned here will be used in the workflow, in this PR: https://github.com/DataDog/synthetics-ci-github-action/pull/371
End goal is to get rid of secrets in the CI.