### PR TITLE
[SINT-4280] update workflows to use dd-octo-sts instead

### DIFF
--- a/.github/workflows/bump-datadog-ci.yml
+++ b/.github/workflows/bump-datadog-ci.yml
@@ -2,10 +2,6 @@
 
 name: Bump Datadog CI
 
-env:
-  GIT_AUTHOR_EMAIL: 'packages@datadoghq.com'
-  GIT_AUTHOR_NAME: 'ci.datadog-ci'
-
 on:
   workflow_dispatch:
     inputs:
@@ -17,18 +13,20 @@ on:
 jobs:
   bump-datadog-ci:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Needed to federate tokens.
     steps:
       # Do the changes
-      - name: Get GitHub App token
-        id: get-token
-        uses: actions/create-github-app-token@v1
+      - name: Get GitHub token via dd-octo-sts
+        id: octo-sts
+        uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         with:
-          app-id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
-          private-key: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
+          scope: DataDog/synthetics-ci-github-action
+          policy: self.bump-datadog-ci.create-pr
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.get-token.outputs.token }}
+          token: ${{ steps.octo-sts.outputs.token }}
       - name: Install node
         uses: actions/setup-node@v4
         with:
@@ -36,10 +34,8 @@ jobs:
           cache: 'yarn'
       - name: Create release branch
         run: git checkout -b local-branch
-      - name: Set git user
-        run: |
-          git config user.name "${GIT_AUTHOR_NAME}"
-          git config user.email "${GIT_AUTHOR_EMAIL}"
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
       - name: Install dependencies
         run: yarn install
       - name: Bump datadog-ci
@@ -54,15 +50,19 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
       - name: Create bump commit
         run: git commit -a --message '[dep] Bump datadog-ci to `${{ steps.bump-datadog-ci.outputs.VERSION }}`'
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
       - name: Push the branch
         run: git push -u origin local-branch:bump-datadog-ci/${{ steps.bump-datadog-ci.outputs.VERSION }}
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
 
       # Create the pull request
       - name: Create pull request
         id: create-pull-request
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.get-token.outputs.token }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const { data: pullRequest } = await github.rest.pulls.create({
               owner: context.repo.owner,
@@ -77,7 +77,7 @@ jobs:
       - name: Create comment
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.get-token.outputs.token }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const body = `This PR was automatically created because a new version of datadog-ci was published.
 

--- a/.github/workflows/release-version-on-merge.yml
+++ b/.github/workflows/release-version-on-merge.yml
@@ -10,17 +10,19 @@ jobs:
   release-version-on-merge:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, '[release:')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Needed to federate tokens.
     steps:
-      - name: Get GitHub App token
-        id: get-token
-        uses: actions/create-github-app-token@v1
+      - name: Get GitHub token via dd-octo-sts
+        id: octo-sts
+        uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         with:
-          app-id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
-          private-key: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
+          scope: DataDog/synthetics-ci-github-action
+          policy: self.release-version-on-merge.create-release
       - name: Create GitHub release
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.get-token.outputs.token }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const tagName = '${{ github.event.pull_request.head.ref }}'.replace('release/', '')
 

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -2,10 +2,6 @@
 
 name: Create Release PR
 
-env:
-  GIT_AUTHOR_EMAIL: 'packages@datadoghq.com'
-  GIT_AUTHOR_NAME: 'ci.datadog-ci'
-
 on:
   workflow_dispatch:
     inputs:
@@ -21,18 +17,20 @@ on:
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Needed to federate tokens.
     steps:
       # Do the changes
-      - name: Get GitHub App token
-        id: get-token
-        uses: actions/create-github-app-token@v1
+      - name: Get GitHub token via dd-octo-sts
+        id: octo-sts
+        uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         with:
-          app-id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
-          private-key: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
+          scope: DataDog/synthetics-ci-github-action
+          policy: self.release-version.create-pr
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.get-token.outputs.token }}
+          token: ${{ steps.octo-sts.outputs.token }}
       - name: Install node
         uses: actions/setup-node@v4
         with:
@@ -40,10 +38,8 @@ jobs:
           cache: 'yarn'
       - name: Create release branch
         run: git checkout -b local-branch
-      - name: Set git user
-        run: |
-          git config user.name "${GIT_AUTHOR_NAME}"
-          git config user.email "${GIT_AUTHOR_EMAIL}"
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
       - name: Install dependencies
         run: yarn install
       - name: Bump CI integration version
@@ -68,15 +64,19 @@ jobs:
         run: |
           git add --all
           git commit -m ${{ steps.bump-version.outputs.NEW_VERSION_TAG }}
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
       - name: Push the branch
         run: git push -u origin local-branch:release/${{ steps.bump-version.outputs.NEW_VERSION_TAG }}
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
 
       # Create the pull request
       - name: Generate release notes
         id: generate-release-notes
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.get-token.outputs.token }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const { data: releaseNotes } = await github.rest.repos.generateReleaseNotes({
               owner: context.repo.owner,
@@ -89,7 +89,7 @@ jobs:
         id: create-pull-request
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.get-token.outputs.token }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const { data: pullRequest } = await github.rest.pulls.create({
               owner: context.repo.owner,
@@ -104,7 +104,7 @@ jobs:
       - name: Create comment
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.get-token.outputs.token }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const body = `Once merged, this PR will automatically create a GitHub release for you.
             The description of the release will exactly match this PR's description. Feel free to edit it.


### PR DESCRIPTION
Now that the policy are in place (https://github.com/DataDog/synthetics-ci-github-action/pull/370), let's update the workflows to use dd-octo-sts provided token, instead of the Github app token.
If this is successful, the last step is to remove the `RELEASE_AUTOMATION_GITHUB_APP_ID` and `RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY` secrets from the repo.

Note: the PRs / commits will be seen as from dd-octo-sts, and not from  'packages@datadoghq.com' / 'ci.datadog-ci'. If some systems rely on this previous Github identity to work, we will need to update them too.