### PR TITLE
[SINT-4287] dd-octo-sts policy to interact with datadog-ci

### DIFF
--- a/.github/chainguard/datadog-ci.publish-release.create-workflow-dispatch.sts.yaml
+++ b/.github/chainguard/datadog-ci.publish-release.create-workflow-dispatch.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-ci:ref:refs/tags/v.*
+
+claim_pattern:
+  event_name: "push"
+  job_workflow_ref: DataDog/datadog-ci/\.github/workflows/publish-release\.yml@refs/tags/v.*
+  ref: refs/tags/v.*
+
+permissions:
+  actions: write


### PR DESCRIPTION
This PR creates a dd-octo-sts policy for `datadog-ci` to be able to trigger a workflow dispatch event in this repo.

End goal is to on-board datadog-ci's [workflow](https://github.com/DataDog/datadog-ci/blob/a45504547b3b4c65dcae857455e53a975646382f/.github/workflows/publish-release.yml#L237-L275) to dd-octo-sts and to remove `secrets.RELEASE_AUTOMATION_GITHUB_APP_ID` and `secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY`