### PR TITLE
fix dd-octo-sts policy

### DIFF
--- a/.github/chainguard/datadog-ci.publish-release.create-workflow-dispatch.sts.yaml
+++ b/.github/chainguard/datadog-ci.publish-release.create-workflow-dispatch.sts.yaml
@@ -1,6 +1,6 @@
 issuer: https://token.actions.githubusercontent.com
 
-subject: repo:DataDog/datadog-ci:ref:refs/tags/v.*
+subject_pattern: repo:DataDog/datadog-ci:ref:refs/tags/v.*
 
 claim_pattern:
   event_name: "push"


### PR DESCRIPTION
Similar to https://github.com/DataDog/datadog-ci/pull/1986
Replaces `subject` with `subject_pattern` to support regexps