### PR TITLE
[synthetics] Transfer Synthetics CT team ownership to Orchestrating and Managing (SYNTH-26305)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global Code Owners
-* @DataDog/synthetics-ct
+* @DataDog/synthetics-orchestrating-managing
 
 # Documentation
-*README.md @DataDog/documentation @DataDog/synthetics-ct
+*README.md @DataDog/documentation @DataDog/synthetics-orchestrating-managing


### PR DESCRIPTION
Transfer `CODEOWNERS` from `@DataDog/synthetics-ct` (team no longer exists) to `@DataDog/synthetics-orchestrating-managing`.

Part of SYNTH-26305.